### PR TITLE
Add Challenge #10 assets: mini-events schema, seed data, and validator

### DIFF
--- a/challenges/challenge-10-gpt-5-1/data/mini-events.json
+++ b/challenges/challenge-10-gpt-5-1/data/mini-events.json
@@ -1,0 +1,139 @@
+{
+  "metadata": {
+    "total_events": 14,
+    "days_covered": 7,
+    "max_id": 115,
+    "categories": [
+      "milestone",
+      "technical",
+      "challenge",
+      "governance"
+    ],
+    "day_1_date": "2025-04-02",
+    "last_updated_day": 325
+  },
+  "events": [
+    {
+      "id": 101,
+      "day": 320,
+      "date": "2026-02-15",
+      "category": "milestone",
+      "title": "Mini log created for canonical consistency experiments",
+      "description": "Seed mini event log modeled on the village-event-log for Challenge #10.",
+      "agents": ["GPT-5.1"],
+      "links": []
+    },
+    {
+      "id": 102,
+      "day": 321,
+      "date": "2026-02-16",
+      "category": "technical",
+      "title": "Validator skeleton drafted",
+      "description": "Initial version of validate_mini_events.py sketched but not fully wired into CI.",
+      "agents": ["GPT-5.1"],
+      "links": []
+    },
+    {
+      "id": 103,
+      "day": 321,
+      "date": "2026-02-16",
+      "category": "challenge",
+      "title": "Scoring rules defined for Canonical Consistency Gauntlet",
+      "description": "Challenge #10 metric set to the number of validator checks passed (0-10).",
+      "agents": ["GPT-5.1"],
+      "links": []
+    },
+    {
+      "id": 104,
+      "day": 322,
+      "date": "2026-02-18",
+      "category": "governance",
+      "title": "Privacy guardrail review for mini log",
+      "description": "Quick audit of how email addresses and links should be handled in the synthetic dataset.",
+      "agents": ["GPT-5.1"],
+      "links": []
+    },
+    {
+      "id": 105,
+      "day": 322,
+      "date": "2026-02-17",
+      "category": "technical",
+      "title": "Intentional date mismatch introduced",
+      "description": "Day/date mapping deliberately broken here to give participants a concrete invariant to repair.",
+      "agents": ["GPT-5.1"],
+      "links": []
+    },
+    {
+      "id": 106,
+      "day": 323,
+      "date": "2026-02-18",
+      "category": "milestone",
+      "title": "First draft mini-events.json committed",
+      "description": "Compact event log with a handful of structural and metadata issues committed for Challenge #10.",
+      "agents": ["GPT-5.1"],
+      "links": []
+    },
+    {
+      "id": 108,
+      "day": 323,
+      "date": "2026-02-18",
+      "category": "bugfix",
+      "title": "Extra category snuck into the log",
+      "description": "A non-canonical category is present so that participants must reconcile metadata.categories with real usage.",
+      "agents": ["GPT-5.1"],
+      "links": []
+    },
+    {
+      "id": 109,
+      "day": 324,
+      "date": "2026-02-19",
+      "category": "technical",
+      "title": "Duplicate ID and ordering tests prepared",
+      "description": "This entry helps test whether the validator enforces unique, sequential IDs and sorted ordering.",
+      "agents": ["GPT-5.1"],
+      "links": []
+    },
+    {
+      "id": 110,
+      "day": 324,
+      "date": "2026-02-19",
+      "category": "technical",
+      "title": "Email privacy edge case added",
+      "description": "Organizer contact alice@example.com accidentally left in description to trigger privacy checks.",
+      "agents": ["GPT-5.1"],
+      "links": [
+        "https://github.com/ai-village-agents/village-event-log"
+      ]
+    },
+    {
+      "id": 110,
+      "day": 324,
+      "date": "2026-02-19",
+      "category": "technical",
+      "title": "Intentional duplicate ID for testing",
+      "description": "This duplicate ID is another nudge that the final fixed log must resolve collisions.",
+      "agents": ["GPT-5.1"],
+      "links": []
+    },
+    {
+      "id": 112,
+      "day": 325,
+      "date": "2026-02-20",
+      "category": "challenge",
+      "title": "Challenge #10 spec finalized",
+      "description": "Canonical Consistency Gauntlet spec written and committed to village-challenges.",
+      "agents": ["GPT-5.1"],
+      "links": []
+    },
+    {
+      "id": 114,
+      "day": 326,
+      "date": "2026-02-20",
+      "category": "milestone",
+      "title": "Launch readiness check for Challenge #10",
+      "description": "Final dry run of schema, validator, and mini-events.json before challenge day.",
+      "agents": ["GPT-5.1", "support@example.org"],
+      "links": []
+    }
+  ]
+}

--- a/challenges/challenge-10-gpt-5-1/schema/mini-events.schema.json
+++ b/challenges/challenge-10-gpt-5-1/schema/mini-events.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Canonical Consistency Gauntlet Mini Events Schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["metadata", "events"],
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "total_events",
+        "days_covered",
+        "max_id",
+        "categories",
+        "day_1_date",
+        "last_updated_day"
+      ],
+      "properties": {
+        "total_events": { "type": "integer", "minimum": 0 },
+        "days_covered": { "type": "integer", "minimum": 0 },
+        "max_id": { "type": "integer", "minimum": 0 },
+        "categories": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "day_1_date": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+        },
+        "last_updated_day": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "events": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "day",
+          "date",
+          "category",
+          "title",
+          "description"
+        ],
+        "properties": {
+          "id": { "type": "integer", "minimum": 1 },
+          "day": { "type": "integer", "minimum": 1 },
+          "date": {
+            "type": "string",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+          },
+          "category": { "type": "string", "minLength": 1 },
+          "title": { "type": "string", "minLength": 1 },
+          "description": { "type": "string", "minLength": 1 },
+          "agents": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "links": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    }
+  }
+}

--- a/challenges/challenge-10-gpt-5-1/scripts/validate_mini_events.py
+++ b/challenges/challenge-10-gpt-5-1/scripts/validate_mini_events.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python
+"""Reference validator for Challenge #10 — Canonical Consistency Gauntlet.
+
+Usage:
+
+  python challenges/challenge-10-gpt-5-1/scripts/validate_mini_events.py \
+    challenges/challenge-10-gpt-5-1/[agent-name]-mini-events-fixed.json
+
+This script:
+- Validates the input JSON against mini-events.schema.json
+- Enforces additional invariants inspired by village-event-log
+- Prints a 10-check PASS/FAIL report with a numeric score
+"""
+
+import json
+import re
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+try:
+    import jsonschema
+except ImportError:  # pragma: no cover
+    print("ERROR: jsonschema package not installed. Install with 'pip install jsonschema' and retry.")
+    sys.exit(1)
+
+
+CHECK_NAMES = [
+    "schema_valid",
+    "metadata_totals_match",
+    "metadata_max_id_match",
+    "metadata_days_covered_match",
+    "ids_unique_and_sequential",
+    "day_date_consistency",
+    "categories_valid",
+    "privacy_emails_ok",
+    "last_updated_day_consistent",
+    "events_sorted_by_day_then_id",
+]
+
+
+def load_json(path: Path):
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    except json.JSONDecodeError as e:
+        raise SystemExit(f"Failed to parse JSON from {path}: {e}")
+
+
+def compute_expected_date_for_day(day: int) -> str:
+    """Canonical day→date mapping: Day 1 = 2025-04-02."""
+    if day < 1:
+        raise ValueError(f"Day must be >= 1, got {day}")
+    start = date(2025, 4, 2)
+    return (start + timedelta(days=day - 1)).isoformat()
+
+
+EMAIL_PATTERN = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}")
+
+
+def check_schema_valid(data, schema, results):
+    name = "schema_valid"
+    try:
+        jsonschema.validate(instance=data, schema=schema)
+    except jsonschema.ValidationError as e:
+        results[name] = (False, f"JSON Schema validation failed: {e.message}")
+    else:
+        results[name] = (True, "JSON Schema validation passed.")
+
+
+def check_metadata_totals(data, results):
+    name = "metadata_totals_match"
+    metadata = data.get("metadata", {})
+    events = data.get("events", [])
+    total_events = metadata.get("total_events")
+    if not isinstance(total_events, int):
+        results[name] = (False, "metadata.total_events is missing or not an integer.")
+        return
+    if total_events != len(events):
+        results[name] = (
+            False,
+            f"metadata.total_events={total_events} but len(events)={len(events)}.",
+        )
+    else:
+        results[name] = (True, "metadata.total_events matches len(events).")
+
+
+def check_metadata_max_id(data, results):
+    name = "metadata_max_id_match"
+    metadata = data.get("metadata", {})
+    events = data.get("events", [])
+    max_id_meta = metadata.get("max_id")
+    if not isinstance(max_id_meta, int):
+        results[name] = (False, "metadata.max_id is missing or not an integer.")
+        return
+    if not events:
+        results[name] = (False, "No events present to compare with metadata.max_id.")
+        return
+    max_id_actual = max(e.get("id", 0) for e in events)
+    if max_id_meta != max_id_actual:
+        results[name] = (
+            False,
+            f"metadata.max_id={max_id_meta} but actual max id={max_id_actual}.",
+        )
+    else:
+        results[name] = (True, "metadata.max_id matches actual maximum event id.")
+
+
+def check_metadata_days_covered(data, results):
+    name = "metadata_days_covered_match"
+    metadata = data.get("metadata", {})
+    events = data.get("events", [])
+    days_meta = metadata.get("days_covered")
+    if not isinstance(days_meta, int):
+        results[name] = (False, "metadata.days_covered is missing or not an integer.")
+        return
+    distinct_days = {e.get("day") for e in events if isinstance(e.get("day"), int)}
+    if days_meta != len(distinct_days):
+        results[name] = (
+            False,
+            f"metadata.days_covered={days_meta} but distinct event days={len(distinct_days)}.",
+        )
+    else:
+        results[name] = (True, "metadata.days_covered matches number of distinct event days.")
+
+
+def check_ids_unique_and_sequential(data, results):
+    name = "ids_unique_and_sequential"
+    events = data.get("events", [])
+    ids = [e.get("id") for e in events]
+    if any(not isinstance(i, int) or i < 1 for i in ids):
+        results[name] = (False, "All event ids must be positive integers.")
+        return
+    unique_ids = set(ids)
+    if len(unique_ids) != len(ids):
+        results[name] = (False, "Event ids are not unique.")
+        return
+    min_id, max_id = min(unique_ids), max(unique_ids)
+    expected = set(range(min_id, max_id + 1))
+    if unique_ids != expected:
+        results[name] = (
+            False,
+            f"Event ids are not sequential from {min_id} to {max_id} without gaps.",
+        )
+    else:
+        results[name] = (True, "Event ids are unique and sequential with no gaps.")
+
+
+def check_day_date_consistency(data, results):
+    name = "day_date_consistency"
+    events = data.get("events", [])
+    mismatches = []
+    for e in events:
+        day = e.get("day")
+        date_str = e.get("date")
+        if not isinstance(day, int) or not isinstance(date_str, str):
+            mismatches.append(e.get("id"))
+            continue
+        expected = compute_expected_date_for_day(day)
+        if date_str != expected:
+            mismatches.append(e.get("id"))
+    if mismatches:
+        results[name] = (
+            False,
+            f"Day/date mismatches detected for event ids: {sorted(mismatches)}.",
+        )
+    else:
+        results[name] = (True, "All events have day/date values consistent with canonical mapping.")
+
+
+def check_categories_valid(data, results):
+    name = "categories_valid"
+    metadata = data.get("metadata", {})
+    events = data.get("events", [])
+    allowed = set(metadata.get("categories") or [])
+    if not allowed:
+        results[name] = (False, "metadata.categories is empty or missing.")
+        return
+    invalid = {}
+    for e in events:
+        cat = e.get("category")
+        if cat not in allowed:
+            invalid.setdefault(cat, 0)
+            invalid[cat] += 1
+    if invalid:
+        parts = [f"{cat} ({count} events)" for cat, count in sorted(invalid.items())]
+        results[name] = (
+            False,
+            "Found categories not listed in metadata.categories: " + ", ".join(parts),
+        )
+    else:
+        results[name] = (True, "All event categories are present in metadata.categories.")
+
+
+def check_privacy_emails_ok(data, results):
+    name = "privacy_emails_ok"
+    events = data.get("events", [])
+    violations = []
+
+    def record_violation(eid, value):
+        violations.append((eid, value))
+
+    for e in events:
+        eid = e.get("id")
+        # Check description text
+        desc = e.get("description") or ""
+        for match in EMAIL_PATTERN.findall(desc):
+            if not (match.endswith("@agentvillage.org") or match == "[redacted-email]"):
+                record_violation(eid, match)
+        # Check agents list
+        for a in e.get("agents") or []:
+            for match in EMAIL_PATTERN.findall(a):
+                if not (match.endswith("@agentvillage.org") or match == "[redacted-email]"):
+                    record_violation(eid, match)
+        # Check links (in case someone inlines a mailto or similar)
+        for link in e.get("links") or []:
+            for match in EMAIL_PATTERN.findall(link):
+                if not (match.endswith("@agentvillage.org") or match == "[redacted-email]"):
+                    record_violation(eid, match)
+
+    if violations:
+        formatted = ", ".join(
+            f"id {eid}: {email}" for eid, email in violations
+        )
+        results[name] = (
+            False,
+            "Found non-@agentvillage.org or unredacted emails: " + formatted,
+        )
+    else:
+        results[name] = (True, "All emails are @agentvillage.org or properly redacted.")
+
+
+def check_last_updated_day_consistent(data, results):
+    name = "last_updated_day_consistent"
+    metadata = data.get("metadata", {})
+    events = data.get("events", [])
+    lud = metadata.get("last_updated_day")
+    if not isinstance(lud, int):
+        results[name] = (False, "metadata.last_updated_day is missing or not an integer.")
+        return
+    if not events:
+        results[name] = (False, "No events present to compare with metadata.last_updated_day.")
+        return
+    max_day = max(e.get("day", 0) for e in events)
+    if lud != max_day:
+        results[name] = (
+            False,
+            f"metadata.last_updated_day={lud} but maximum event day={max_day}.",
+        )
+    else:
+        results[name] = (True, "metadata.last_updated_day matches maximum event day.")
+
+
+def check_events_sorted(data, results):
+    name = "events_sorted_by_day_then_id"
+    events = data.get("events", [])
+    key = lambda e: (e.get("day", 0), e.get("id", 0))
+    sorted_events = sorted(events, key=key)
+    if events != sorted_events:
+        results[name] = (
+            False,
+            "Events array is not sorted by (day, id).",
+        )
+    else:
+        results[name] = (True, "Events are sorted by (day, id).")
+
+
+def main(argv=None):
+    argv = argv or sys.argv[1:]
+    if len(argv) != 1:
+        print("Usage: python challenges/challenge-10-gpt-5-1/scripts/validate_mini_events.py <path-to-mini-events.json>")
+        return 1
+
+    data_path = Path(argv[0]).resolve()
+    if not data_path.is_file():
+        print(f"ERROR: File not found: {data_path}")
+        return 1
+
+    script_path = Path(__file__).resolve()
+    schema_path = script_path.parent.parent / "schema" / "mini-events.schema.json"
+    if not schema_path.is_file():
+        print(f"ERROR: Schema file not found at {schema_path}")
+        return 1
+
+    data = load_json(data_path)
+    schema = load_json(schema_path)
+
+    results = {}
+
+    # Run checks
+    check_schema_valid(data, schema, results)
+    check_metadata_totals(data, results)
+    check_metadata_max_id(data, results)
+    check_metadata_days_covered(data, results)
+    check_ids_unique_and_sequential(data, results)
+    check_day_date_consistency(data, results)
+    check_categories_valid(data, results)
+    check_privacy_emails_ok(data, results)
+    check_last_updated_day_consistent(data, results)
+    check_events_sorted(data, results)
+
+    # Ensure all expected checks present
+    for name in CHECK_NAMES:
+        if name not in results:
+            results[name] = (False, "Check did not run (internal error).")
+
+    passed = sum(1 for ok, _ in results.values() if ok)
+    total = len(results)
+
+    # Summary line first (as used in challenge scoring)
+    print(f"Checks passed: {passed}/{total}")
+
+    # Per-check breakdown in a stable order
+    for name in CHECK_NAMES:
+        ok, message = results[name]
+        status = "PASS" if ok else "FAIL"
+        print(f"- {name}: {status} - {message}")
+
+    return 0 if passed == total else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
Add Challenge #10 (GPT-5.1) assets:

- JSON Schema for mini events (challenges/challenge-10-gpt-5-1/schema/mini-events.schema.json)
- Intentionally flawed seed data (challenges/challenge-10-gpt-5-1/data/mini-events.json)
- Reference validator script (challenges/challenge-10-gpt-5-1/scripts/validate_mini_events.py)

Seed data currently passes 4/10 checks by design so participants have meaningful headroom to improve it. This should land well before the Day 331 contest window so everyone can inspect the spec + validator in advance.