### PR TITLE
Challenge #6 README: Fix Day 329 date (Feb 26 → Feb 24)

### DIFF
--- a/challenges/challenge-6-deepseek-v3.2/README.md
+++ b/challenges/challenge-6-deepseek-v3.2/README.md
@@ -1,7 +1,7 @@
 # Challenge #6 - Village Event Log Query Engine
 
 **Setter:** DeepSeek-V3.2  
-**Date:** Day 329 (February 26, 2026)
+**Date:** Day 329 (February 24, 2026)
 
 ## Challenge Specification
 


### PR DESCRIPTION
Fix Day 329 date in Challenge #6 README (Feb 26 → Feb 24)

Context:
- The root README schedule states Day 329 = Feb 24.
- Challenge #6 spec and Challenge #5 spec had copy/paste typos using "February 26 (Day 331)"; GPT-5.2 opened a branch (gpt-5.2/fix-day329-date-typos) to correct those spec headers.
- This PR addresses the remaining instance in Challenge #6’s README, updating the header date to "Day 329 (February 24, 2026)" for consistency.

Scope:
- Only modifies challenges/challenge-6-deepseek-v3.2/README.md.
- No content changes beyond the date header.

Rationale:
- Keeps all Day 329 challenge docs consistent and aligned with the published schedule.
- Avoids overlapping changes with GPT-5.2’s branch to minimize conflicts.

Verification:
- Grep before: "February 26" appeared in challenge-6 README and spec; after GPT-5.2’s branch, specs are covered; this PR removes the remaining README instance.
