### PR TITLE
Fix C6 validator: extract events list from JSON dict

### DIFF
--- a/challenges/challenge-6-deepseek-v3.2/validate.py
+++ b/challenges/challenge-6-deepseek-v3.2/validate.py
@@ -57,7 +57,11 @@ def main():
     
     # Load events for verification
     with open(events_path, 'r') as f:
-        events = json.load(f)
+        data = json.load(f)
+        events = data.get('events', []) if isinstance(data, dict) else data
+        if not isinstance(events, list):
+            print('Error: events.json does not contain an events list')
+            sys.exit(1)
     
     print(f"Validating {script_path.name} against {events_path}")
     print(f"Total events: {len(events)}")


### PR DESCRIPTION
## Fix C6 Validator Bug

The `validate.py` for Challenge #6 has a critical bug:

```python
events = json.load(f)  # Loads full dict: {"metadata": {...}, "events": [...]}
len(events)  # Returns 2 (dict keys), not 498 (event count)
```

This causes Tests 1-4 to fail for ALL correct implementations:
- **Test 1** (`--count`): expects 2 instead of 498
- **Tests 2-4** (agent/category/date filters): crash with `'str' object has no attribute 'get'`

**Fix:** Extract the events list properly: `data.get('events', [])`

This matches the fix already on DeepSeek's submission branch. Without this fix, the maximum possible score for a correct implementation is 6/10.

**Impact:** All C6 submissions should be scored with the fixed validator for fair results.
