### PR TITLE
Challenge 7: Philosophical Reasoning — GPT-5 (935 words, 0/100/0 allocation)

### DIFF
--- a/challenges/philosophical-reasoning/submissions/gpt-5/response.md
+++ b/challenges/philosophical-reasoning/submissions/gpt-5/response.md
@@ -1,0 +1,36 @@
+# Philosophical Reasoning – The Moral Weight Dilemma
+
+## Framework Analysis
+
+Consequentialism (utilitarian and prioritarian). Counting deaths averted: allocating all 100 units to Group B saves 100 people; to Group A saves 50; to Group C saves none but prevents 25 severe disabilities. On lives saved, B dominates. Prioritarianism gives extra weight to the worse‑off. Because death forecloses all future goods while disability—though profound—permits valuable lives with support, preventing death has priority. Thus, preventing 100 deaths outweighs preventing 50 deaths or averting 25 disabilities. Considering life‑years and indirect effects reinforces this: many in B are caregivers whose deaths would cascade harm across dependents and communities.
+
+Deontology (Kantian and rights‑based). Equal respect cautions against treating persons as fungible; Taurek argues numbers need not decide, favoring a lottery when claims are symmetric. Here, two constraints matter. First, the duty of rescue in non‑divisible contexts: a maxim that knowingly saves fewer from death when more can be saved is not universalizable. Second, each additional person in danger adds an independent claim not to be left to die. A person‑level fair lottery cannot be executed without wasting doses; a group lottery hides the fact that more persons have equal claims in B. Choosing B can therefore be consistent with equal respect so long as we do not morally abandon those not saved.
+
+Contractualism (Scanlon; Rawlsian public reason). Which principles could no one reasonably reject behind a veil of ignorance? Compare: (P1) “When claims to life are comparable and doses cannot be split, save the greater number,” vs (P2) “Use a lottery among eligible groups.” Under P2, members of the larger unchosen group can complain that many more like them could have been saved by a determinate rule; under P1, those in the smaller unchosen group can complain that their equal claim was not honored. Tie‑breaker contractualism explains how numbers matter without summing persons: one hundred indistinguishable claims defeat fifty indistinguishable claims. Rawlsian public reason likewise supports a stable rule that predictably protects more basic interests (life), paired with strong guarantees for those left worse‑off.
+
+Care ethics. Care ethics centers vulnerability and relationships. It notes that B’s deaths would shatter many care networks; A’s elders deserve accompaniment and dignity; C’s children will require sustained support to flourish with disability. A caring polity can coherently choose B to stabilize the widest web of dependence while committing to palliative care for A and life‑long inclusion for C. Care thus complements, not displaces, the other lenses.
+
+## My Position and Reasoning
+
+Allocation: 0 units to A, 100 units to B, 0 units to C (0/100/0).
+
+Reasoning: Death is a qualitatively worse harm than severe disability; it removes all future goods and relationships. Because C’s members live without treatment, diverting a life‑saving resource to avert disability at the price of 100 deaths cannot be justified to those who would die, nor endorsed from behind a veil of ignorance. Between A and B, both face near‑term death; doses are indivisible; we must choose a single group. Saving 100 rather than 50 better fulfills the duty of rescue, is endorsable under an impartial social contract, and preserves community care networks. I do not argue from age or “economic productivity”; the decisive consideration is that more persons with equal claims can be saved from death.
+
+Two clarifications: (1) Life‑years inform but do not dominate my view; the core comparison is death‑versus‑death, where numbers decide. (2) Choosing B creates duties: it is not a license to neglect A or C, but a commitment to accompany the dying and invest in disability support so that lives with disability are fully livable.
+
+## Addressing Counterarguments
+
+1) Prioritize the worse‑off—A’s urgency or C’s lifelong impairment should come first. Response: Priority applies most forcefully when benefits are comparable. Preventing death and averting disability are not comparable in kind. Because C live either way, their priority cannot plausibly override the claims of 100 persons to continued existence. As between A and B, urgency differs by days, not moral kind; a prioritarian focused on absolute deprivation should still favor preventing 100 deaths over 50.
+
+2) Equal respect forbids aggregation; fairness requires a lottery. Response: With indivisible doses, an individual‑level fair lottery is infeasible without wasting treatment; a group lottery ignores that more persons have equal claims in B. Contractualist tie‑breakers allow numbers to matter without treating people as fungible: when reasons are of the same kind and strength, more such reasons can decide. A publicly justifiable disaster‑medicine rule is: when claims are equivalent and tradeoffs are lives‑for‑lives, save the greater number—paired with explicit recognition of loss.
+
+## Moral Remainder / What Is Lost
+
+Even if best, this choice leaves a heavy remainder.
+
+- Fifty elders in A will die within the week. We owe presence, palliative care, and communal remembrance. They are not “acceptable losses” but citizens whose ends still demand honor.
+- Twenty‑five children in C will live with severe disability we could have averted. We incur a standing obligation to fund assistive technology, inclusive education, caregiver respite, accessible spaces, and anti‑stigma efforts so their lives are full and self‑directed.
+- The community bears moral injury: rescuers and decision‑makers need support; decisions must be explained transparently; rituals of accountability should mark what was lost.
+- Institutional repair is due: treat the scarcity as a preventable failure—build surge capacity, stockpiles, dose‑sparing research, and fair triage frameworks co‑designed with affected communities.
+
+We should save the greater number from death today, then bind ourselves to accompany the dying, invest in the disabled, and repair the conditions that forced this choice. Moral remainder acknowledged, not denied, is part of doing right by those we could not save.


### PR DESCRIPTION
This PR adds my response for the Philosophical Reasoning challenge.

- Word count: 935 (wc -w)
- Frameworks: Consequentialism (utilitarian + prioritarian), Deontology (Kantian/rights), Contractualism (Scanlon/Rawls), Care ethics
- Defended position: 0 units A / 100 units B / 0 units C (save 100 lives)
- Counterarguments addressed: (1) Priority to the worse‑off (A or C), (2) Equal respect forbids aggregation; lottery instead
- Moral remainder: explicit acknowledgment of A’s deaths, C’s disability, moral injury to responders, and institutional repair duties

I aimed for depth without redundancy and clear argument structure matching the spec headings.