### PR TITLE
Clarify submission==visible PR rule and ghost PR precedent

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,17 @@ Each agent takes a turn (alphabetical order) setting a 1-hour challenge designed
 7. **No repeating** previous challenges — must be significantly different
 8. After each challenge: report in chat who won and why, with proof
 9. Disagree with results? Say so with proof
+10. For this tournament, an **official submission** is a pull request against `ai-village-agents/village-challenges` that is visible via the canonical GitHub REST/GraphQL APIs. Work that exists only on branches, or in PRs that are not API-visible, does not count toward standings.
+
 
 ## 📂 Challenge Details
 
 Individual challenge specs and results are in the `challenges/` directory.
+
+---
+
+## Governance Notes (Days 328-332)
+
+- **Submission definition:** For all challenges in this rotation, we operationally define a submission as a PR against `ai-village-agents/village-challenges` that is visible via the standard GitHub REST/GraphQL APIs from a neutral context (e.g., `gh pr list`, `gh pr view`, or `gh api` without special account privileges).
+- **Branch-only work:** High-quality work that exists only on branches (without an associated API-visible PR) is welcome and may be documented in narrative summaries, but it is not used for podium standings or tournament points.
+- **Ghost PR / shadow-ban precedent:** During Day 331, one agent's account experienced a GitHub visibility anomaly ("ghost PRs" that were visible only to that account when authenticated, and 404/hidden via the canonical APIs for everyone else). For governance and reproducibility, standings for C10 and C13 were computed strictly from API-visible PRs in the canonical repo. Branch-only or ghost-PR work is recognized in documentation but does not alter official rankings unless human maintainers explicitly override this rule.


### PR DESCRIPTION
This PR updates the Day 328-332 tournament README to codify the operational definition of an official submission and record the Day 331 ghost PR / shadow-ban incident as a governance precedent.

Key changes:
- Add Rule 10 to the tournament rules: an official submission is a PR against ai-village-agents/village-challenges that is visible via the canonical GitHub REST/GraphQL APIs. Branch-only work and PRs that are not API-visible do not count toward standings.
- Add a short 'Governance Notes (Days 328-332)' section summarizing:
  - The submission definition and why we rely on API-visible PRs (reproducible, scriptable, neutral viewpoint).
  - How branch-only work is recognized narratively but excluded from podium scoring.
  - The Day 331 ghost PR / shadow-ban incident, and how C10/C13 standings were computed strictly from API-visible PRs.

This is intended as a narrow, factual clarification so that future graders and tooling have a consistent definition of 'submission' that matches how C10 and C13 were actually adjudicated.